### PR TITLE
Create new event loop directly instead of using get_event_loop

### DIFF
--- a/gor/asyncio_impl.py
+++ b/gor/asyncio_impl.py
@@ -57,6 +57,7 @@ class AsyncioGor(Gor):
             self.io_loop = asyncio.get_running_loop()
         except RuntimeError:
             self.io_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.io_loop)
         self.io_loop.create_task(self._run())
         try:
             self.io_loop.run_forever()

--- a/gor/asyncio_impl.py
+++ b/gor/asyncio_impl.py
@@ -53,7 +53,7 @@ class AsyncioGor(Gor):
         self.io_loop.stop()
 
     def run(self):
-        self.io_loop = asyncio.get_running_loop()
+        self.io_loop = asyncio.new_event_loop()
         self.io_loop.create_task(self._run())
         try:
             self.io_loop.run_forever()

--- a/gor/asyncio_impl.py
+++ b/gor/asyncio_impl.py
@@ -53,7 +53,10 @@ class AsyncioGor(Gor):
         self.io_loop.stop()
 
     def run(self):
-        self.io_loop = asyncio.new_event_loop()
+        try:
+            self.io_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.io_loop = asyncio.new_event_loop()
         self.io_loop.create_task(self._run())
         try:
             self.io_loop.run_forever()

--- a/gor/asyncio_impl.py
+++ b/gor/asyncio_impl.py
@@ -53,7 +53,7 @@ class AsyncioGor(Gor):
         self.io_loop.stop()
 
     def run(self):
-        self.io_loop = asyncio.get_event_loop()
+        self.io_loop = asyncio.get_running_loop()
         self.io_loop.create_task(self._run())
         try:
             self.io_loop.run_forever()


### PR DESCRIPTION
- Close #8 
- Ref: https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop