### PR TITLE
Support gzip encoding http response

### DIFF
--- a/gor/base.py
+++ b/gor/base.py
@@ -7,7 +7,7 @@ import binascii
 import datetime
 import traceback
 from urllib.parse import quote_plus, urlparse, parse_qs
-from typing import Union, Dict
+from typing import Dict
 
 
 def gor_hex_data(data):
@@ -115,14 +115,12 @@ class Gor(object):
     def set_http_status(self, payload: bytes, new_status: str) -> bytes:
         return self.set_http_path(payload, new_status)
 
-    def http_headers(self, payload: Union[bytes, str]) -> Dict[str, str]:
+    def http_headers(self, payload: bytes) -> Dict[str, str]:
         """
         Parse the payload and return http headers in a map
         :param payload: the http payload to inspect
         :return: a map mapping from key to value of each http header item
         """
-        if isinstance(payload, str):
-            payload = payload.encode()
         start_index = payload.index(b"\r\n")
         end_index = payload.index(b"\r\n\r\n")
         if end_index == -1:
@@ -135,7 +133,7 @@ class Gor(object):
             headers[key] = value
         return headers
 
-    def http_header(self, payload: Union[bytes, str], name: str) -> Dict[str, str]:
+    def http_header(self, payload: bytes, name: str) -> Dict[str, str]:
         current_line = 0
         idx = 0
         header = {
@@ -143,8 +141,6 @@ class Gor(object):
             'end': -1,
             'value_start': -1,
         }
-        if isinstance(payload, str):
-            payload = payload.encode()
         name = name.encode()
         while idx < len(payload):
             c = payload[idx]
@@ -175,9 +171,7 @@ class Gor(object):
             idx += 1
         return None
 
-    def set_http_header(self, payload: Union[bytes, str], name: str, value: str) -> bytes:
-        if isinstance(payload, str):
-            payload = payload.encode()
+    def set_http_header(self, payload: bytes, name: str, value: str) -> bytes:
         header = self.http_header(payload, name)
         if header is None:
             header_start = payload.index(b'\n') + 1
@@ -185,9 +179,7 @@ class Gor(object):
         else:
             return payload[:header['value_start']] + b' ' + value.encode() + b'\r\n' + payload[header['end']:]
 
-    def delete_http_header(self, payload: Union[bytes, str], name: str) -> bytes:
-        if isinstance(payload, str):
-            payload = payload.encode()
+    def delete_http_header(self, payload: bytes, name: str) -> bytes:
         header = self.http_header(payload, name)
         if header is None:
             return payload

--- a/gor/base.py
+++ b/gor/base.py
@@ -7,6 +7,7 @@ import binascii
 import datetime
 import traceback
 from urllib.parse import quote_plus, urlparse, parse_qs
+from typing import Union, Dict
 
 
 def gor_hex_data(data):
@@ -114,7 +115,7 @@ class Gor(object):
     def set_http_status(self, payload: bytes, new_status: str) -> bytes:
         return self.set_http_path(payload, new_status)
 
-    def http_headers(self, payload: bytes) -> dict[str, str]:
+    def http_headers(self, payload: Union[bytes, str]) -> Dict[str, str]:
         """
         Parse the payload and return http headers in a map
         :param payload: the http payload to inspect
@@ -134,7 +135,7 @@ class Gor(object):
             headers[key] = value
         return headers
 
-    def http_header(self, payload: bytes, name: str) -> dict[str, str]:
+    def http_header(self, payload: Union[bytes, str], name: str) -> Dict[str, str]:
         current_line = 0
         idx = 0
         header = {
@@ -174,7 +175,7 @@ class Gor(object):
             idx += 1
         return None
 
-    def set_http_header(self, payload: bytes, name: str, value: str) -> bytes:
+    def set_http_header(self, payload: Union[bytes, str], name: str, value: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)
@@ -184,7 +185,7 @@ class Gor(object):
         else:
             return payload[:header['value_start']] + b' ' + value.encode() + b'\r\n' + payload[header['end']:]
 
-    def delete_http_header(self, payload: bytes, name: str) -> bytes:
+    def delete_http_header(self, payload: Union[bytes, str], name: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)

--- a/gor/base.py
+++ b/gor/base.py
@@ -114,7 +114,7 @@ class Gor(object):
     def set_http_status(self, payload: bytes, new_status: str) -> bytes:
         return self.set_http_path(payload, new_status)
 
-    def http_headers(self, payload: bytes|str) -> dict[str, str]:
+    def http_headers(self, payload: bytes) -> dict[str, str]:
         """
         Parse the payload and return http headers in a map
         :param payload: the http payload to inspect
@@ -134,7 +134,7 @@ class Gor(object):
             headers[key] = value
         return headers
 
-    def http_header(self, payload: bytes|str, name: str) -> dict[str, str]:
+    def http_header(self, payload: bytes, name: str) -> dict[str, str]:
         current_line = 0
         idx = 0
         header = {
@@ -174,7 +174,7 @@ class Gor(object):
             idx += 1
         return None
 
-    def set_http_header(self, payload: bytes|str, name: str, value: str) -> bytes:
+    def set_http_header(self, payload: bytes, name: str, value: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)
@@ -184,7 +184,7 @@ class Gor(object):
         else:
             return payload[:header['value_start']] + b' ' + value.encode() + b'\r\n' + payload[header['end']:]
 
-    def delete_http_header(self, payload: bytes|str, name: str) -> bytes:
+    def delete_http_header(self, payload: bytes, name: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)

--- a/gor/base.py
+++ b/gor/base.py
@@ -7,7 +7,6 @@ import binascii
 import datetime
 import traceback
 from urllib.parse import quote_plus, urlparse, parse_qs
-from typing import Union
 
 
 def gor_hex_data(data):
@@ -115,7 +114,7 @@ class Gor(object):
     def set_http_status(self, payload: bytes, new_status: str) -> bytes:
         return self.set_http_path(payload, new_status)
 
-    def http_headers(self, payload: Union[bytes, str]) -> dict[str, str]:
+    def http_headers(self, payload: bytes|str) -> dict[str, str]:
         """
         Parse the payload and return http headers in a map
         :param payload: the http payload to inspect
@@ -135,7 +134,7 @@ class Gor(object):
             headers[key] = value
         return headers
 
-    def http_header(self, payload: Union[bytes, str], name: str) -> dict[str, str]:
+    def http_header(self, payload: bytes|str, name: str) -> dict[str, str]:
         current_line = 0
         idx = 0
         header = {
@@ -175,7 +174,7 @@ class Gor(object):
             idx += 1
         return None
 
-    def set_http_header(self, payload: Union[bytes, str], name: str, value: str) -> bytes:
+    def set_http_header(self, payload: bytes|str, name: str, value: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)
@@ -185,7 +184,7 @@ class Gor(object):
         else:
             return payload[:header['value_start']] + b' ' + value.encode() + b'\r\n' + payload[header['end']:]
 
-    def delete_http_header(self, payload: Union[bytes, str], name: str) -> bytes:
+    def delete_http_header(self, payload: bytes|str, name: str) -> bytes:
         if isinstance(payload, str):
             payload = payload.encode()
         header = self.http_header(payload, name)

--- a/tests/test_gor.py
+++ b/tests/test_gor.py
@@ -22,29 +22,30 @@ class TestCommon(unittest.TestCase):
             "type": "1",
             "id": "2",
             "meta": ["1", "2", "3"],
-            "http": "GET / HTTP/1.1\r\n\r\n",
+            "http": b"GET / HTTP/1.1\r\n\r\n",
         }
         for k, v in expected.items():
             self.assertEqual(getattr(message, k, None), v)
 
     def test_http_method(self):
-        payload = 'GET /test HTTP/1.1\r\n\r\n'
+        payload = b'GET /test HTTP/1.1\r\n\r\n'
         method = self.gor.http_method(payload)
         self.assertEqual(method, 'GET')
 
     def test_http_path(self):
-        payload = "GET /test HTTP/1.1\r\n\r\n"
+        payload = b"GET /test HTTP/1.1\r\n\r\n"
         path = self.gor.http_path(payload)
         self.assertEqual(path, "/test")
 
-        new_payload = self.gor.set_http_path(payload, "/")
-        self.assertEqual(new_payload, "GET / HTTP/1.1\r\n\r\n")
+        unicode_path = "/emoji/😊".encode('utf-8')
+        new_payload = self.gor.set_http_path(payload, unicode_path)
+        self.assertEqual(new_payload, b"GET /emoji/\xf0\x9f\x98\x8a HTTP/1.1\r\n\r\n")
 
-        new_payload = self.gor.set_http_path(payload, "/new/test")
-        self.assertEqual(new_payload, "GET /new/test HTTP/1.1\r\n\r\n")
+        new_payload = self.gor.set_http_path(payload, b"/new/test")
+        self.assertEqual(new_payload, b"GET /new/test HTTP/1.1\r\n\r\n")
 
     def test_http_path_param(self):
-        payload = 'GET / HTTP/1.1\r\n\r\n'
+        payload = b'GET / HTTP/1.1\r\n\r\n'
         self.assertIsNone(self.gor.http_path_param(payload, 'test'))
 
         payload = self.gor.set_http_path_param(payload, 'test', '123')
@@ -84,40 +85,44 @@ class TestCommon(unittest.TestCase):
         expected = 'GET / HTTP/1.1\r\nUser-Agent: %s\r\nContent-Length: 5\r\n\r\nhello'
         for ua in uas:
             new_payload = self.gor.set_http_header(payload, 'User-Agent', ua)
-            self.assertEqual(new_payload, expected % ua)
+            self.assertEqual(new_payload, (expected % ua).encode())
 
-        expected = 'GET / HTTP/1.1\r\nX-Test: test\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
+        expected = b'GET / HTTP/1.1\r\nX-Test: test\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
         new_payload = self.gor.set_http_header(payload, 'X-Test', 'test')
         self.assertEqual(new_payload, expected)
 
-        expected = 'GET / HTTP/1.1\r\nX-Test2: test2\r\nX-Test: test\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
+        expected = b'GET / HTTP/1.1\r\nX-Test2: test2\r\nX-Test: test\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
         new_payload = self.gor.set_http_header(new_payload, 'X-Test2', 'test2')
         self.assertEqual(new_payload, expected)
 
     def test_delete_http_header(self):
         payload = b'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
         new_payload = self.gor.delete_http_header(payload, 'User-Agent')
-        self.assertEqual(new_payload, 'GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello')
+        self.assertEqual(new_payload, b'GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello')
         new_payload = self.gor.delete_http_header(new_payload, 'not-exists-header')
-        self.assertEqual(new_payload, 'GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello')
+        self.assertEqual(new_payload, b'GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello')
 
     def test_http_body(self):
-        payload = 'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
+        payload = b'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
         body = self.gor.http_body(payload)
-        self.assertEqual(body, 'hello')
+        self.assertEqual(body, b'hello')
 
-        invalid_payload = 'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\nhello'
+        gzip_payload = b'HTTP/1.1 200 OK\r\nServer: nginx/1.23.1\r\nDate: Sun, 11 Sep 2022 15:28:34 GMT\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\nVary: Accept-Encoding\r\nContent-Encoding: gzip\r\n\r\n5d\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\x03\xabVJ\xceOIU\xb2R2T\xd2QP\xcaM-.NL\x07r\x15\x942Rsr\xf2Ab)\xa9%\x89\x999 \xa1\x97\xbb[\x9em\xda\xfc\xb8\xa1\xf1\xe5\xd4\xfd\xcf6\xce\x7f\xdc\xd0\x94\x9a\x9b\x9f\x95i\xa5\xf0a\xfe\x8c. O\xa9\x16\x00Z)\xad4N\x00\x00\x00\r\n0'
+        body = self.gor.http_body(gzip_payload)
+        self.assertEqual(body, b'5d\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\x03\xabVJ\xceOIU\xb2R2T\xd2QP\xcaM-.NL\x07r\x15\x942Rsr\xf2Ab)\xa9%\x89\x999 \xa1\x97\xbb[\x9em\xda\xfc\xb8\xa1\xf1\xe5\xd4\xfd\xcf6\xce\x7f\xdc\xd0\x94\x9a\x9b\x9f\x95i\xa5\xf0a\xfe\x8c. O\xa9\x16\x00Z)\xad4N\x00\x00\x00\r\n0')
+
+        invalid_payload = b'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\nhello'
         body = self.gor.http_body(invalid_payload)
-        self.assertEqual(body, '')
+        self.assertEqual(body, b'')
 
     def test_set_http_body(self):
-        payload = 'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
-        new_payload = self.gor.set_http_body(payload, 'hello, world!')
-        expected = 'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 13\r\n\r\nhello, world!'
+        payload = b'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 5\r\n\r\nhello'
+        new_payload = self.gor.set_http_body(payload, b'hello, world!')
+        expected = b'GET / HTTP/1.1\r\nUser-Agent: Python\r\nContent-Length: 13\r\n\r\nhello, world!'
         self.assertEqual(new_payload, expected)
 
     def test_http_cookie(self):
-        payload = 'GET / HTTP/1.1\r\nCookie: a=b; test=zxc; test2=a=b\r\n\r\n'
+        payload = b'GET / HTTP/1.1\r\nCookie: a=b; test=zxc; test2=a=b\r\n\r\n'
         cookie = self.gor.http_cookie(payload, 'test')
         self.assertEqual(cookie, 'zxc')
         cookie = self.gor.http_cookie(payload, 'test2')
@@ -128,11 +133,19 @@ class TestCommon(unittest.TestCase):
     def test_set_http_cookie(self):
         payload = b'GET / HTTP/1.1\r\nCookie: a=b; test=zxc\r\n\r\n'
         new_payload = self.gor.set_http_cookie(payload, 'test', '111')
-        self.assertEqual(new_payload, 'GET / HTTP/1.1\r\nCookie: a=b; test=111\r\n\r\n')
+        self.assertEqual(new_payload, b'GET / HTTP/1.1\r\nCookie: a=b; test=111\r\n\r\n')
         new_payload = self.gor.set_http_cookie(payload, 'new', 'one%3d%3d--test')
-        self.assertEqual(new_payload, 'GET / HTTP/1.1\r\nCookie: a=b; test=zxc; new=one%3d%3d--test\r\n\r\n')
+        self.assertEqual(new_payload, b'GET / HTTP/1.1\r\nCookie: a=b; test=zxc; new=one%3d%3d--test\r\n\r\n')
 
     def test_delete_http_cookie(self):
         payload = b'GET / HTTP/1.1\r\nCookie: a=b; test=zxc\r\n\r\n'
         new_payload = self.gor.delete_http_cookie(payload, 'test')
-        self.assertEqual(new_payload, 'GET / HTTP/1.1\r\nCookie: a=b\r\n\r\n')
+        self.assertEqual(new_payload, b'GET / HTTP/1.1\r\nCookie: a=b\r\n\r\n')
+
+    '''
+    def test_decompress_gzip_body(self):
+        gzip_body_hex = '485454502f312e3120323030204f4b0d0a5365727665723a206e67696e782f312e32332e310d0a446174653a204d6f6e2c2031322053657020323032322030313a30383a343120474d540d0a436f6e74656e742d547970653a206170706c69636174696f6e2f6a736f6e0d0a5472616e736665722d456e636f64696e673a206368756e6b65640d0a436f6e6e656374696f6e3a206b6565702d616c6976650d0a566172793a204163636570742d456e636f64696e670d0a436f6e74656e742d456e636f64696e673a20677a69700d0a0d0a35640d0a1f8b0800000000000403ab564ace4f4955b2523254d25150ca4d2d2e4e4c0772159432527372f2416229a92589993920a197bb5b9e6ddafcb8a1f1e5d4fdcf36ce7fdcd0949a9b9f9569a5f061fe8c2e204fa916005a29ad344e0000000d0a300d0a0d0a'
+        gzip_payload = bytes.fromhex(gzip_body_hex)
+        body = self.gor.decompress_gzip_body(gzip_payload)
+        self.assertEqual(body, '')
+    '''


### PR DESCRIPTION
ref: #13 
- [x] Record raw http in GorMessage in `bytes` type, and change all http methods to support bytes payload.
- [ ] TODO: add support for chunked transfer encoding and gzip content encoding.